### PR TITLE
Update PredictiveSDK to v1.5.1

### DIFF
--- a/Integration/PredictiveSDK-iOS/PredictiveSDKSample.xcodeproj/project.pbxproj
+++ b/Integration/PredictiveSDK-iOS/PredictiveSDKSample.xcodeproj/project.pbxproj
@@ -559,7 +559,7 @@
 			repositoryURL = "https://github.com/FleksySDK/PredictiveSDK-iOS";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 1.4.0;
+				minimumVersion = 1.5.1;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */


### PR DESCRIPTION
chore: update minimum version of PredictiveTextSDK to v1.5.1 in iOS demo project